### PR TITLE
Refactors ETag support

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	gf := gofetch.New(
 		gofetch.DestDir("/tmp"),
-		gofetch.Concurrency(10),
+		gofetch.Concurrency(100),
 		gofetch.ETag(true),
 	)
 

--- a/gofetch.go
+++ b/gofetch.go
@@ -64,14 +64,16 @@ func ETag(enable bool) option {
 
 var workDir string
 
-// New creates a new instance of goFetch with the given options.
-func New(opts ...option) *goFetch {
+func init() {
 	dir, err := homedir.Dir()
 	if err != nil {
 		fmt.Printf(`Unable to get user home directory err=%s\n`, err)
 	}
 	workDir = filepath.Join(dir, ".gofetch")
+}
 
+// New creates a new instance of goFetch with the given options.
+func New(opts ...option) *goFetch {
 	// Creates instance and assigns defaults.
 	gofetch := &goFetch{
 		concurrency: 1,

--- a/gofetch.go
+++ b/gofetch.go
@@ -39,6 +39,7 @@ type goFetch struct {
 type option func(*goFetch)
 
 // DestDir allows you to set the destination directory for the downloaded files.
+// By default it is set to: ./
 func DestDir(dir string) option {
 	return func(f *goFetch) {
 		f.destDir = dir
@@ -46,7 +47,7 @@ func DestDir(dir string) option {
 }
 
 // Concurrency allows you to set the number of goroutines used to download a specific
-// file.
+// file. By default it is set to 1.
 func Concurrency(c int) option {
 	return func(f *goFetch) {
 		f.concurrency = c
@@ -54,8 +55,12 @@ func Concurrency(c int) option {
 }
 
 // ETag allows you to disable or enable ETag support, meaning that if an already
-// downloaded file is currently on disk and matches the ETag returned by the server,
-// it will not be downloaded again.
+// downloaded file is currently on disk and matches the ETag value returned by the server,
+// it will not be downloaded again. By default it is set to true.
+
+// Be aware that different servers, serving the same file, are likely to return
+// different ETag values, causing the file to be re-downloaded, even though it
+// might already exist on disk.
 func ETag(enable bool) option {
 	return func(f *goFetch) {
 		f.etag = enable


### PR DESCRIPTION
There are a couple of changes in this PR: 
- Creates a gofetch working directory under `~/.gofetch`, right now it is only used to cache etag values.
- Uses individual temp directories per test
- Refactors etag support and its tests.
